### PR TITLE
Add image badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ansible-lint
 
 [![](https://images.microbadger.com/badges/image/oildex/ansible-lint.svg)](https://microbadger.com/images/oildex/ansible-lint)
+[![Anchore Image Overview](https://anchore.io/service/badges/image/c55de5d565e773b2452270963fea715757d3fd71ab2199c3525b90cd260f5591)](https://anchore.io/image/dockerhub/oildex%2Fansible-lint%3Alatest)
 
 [Ansible-lint](https://github.com/willthames/ansible-lint) checks Ansible playbooks for practices and behaviour that could potentially be improved.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ansible-lint
 
+[![](https://images.microbadger.com/badges/image/oildex/ansible-lint.svg)](https://microbadger.com/images/oildex/ansible-lint)
+
 [Ansible-lint](https://github.com/willthames/ansible-lint) checks Ansible playbooks for practices and behaviour that could potentially be improved.
 
 This repository extends the official [python](https://hub.docker.com/_/python) image by installing the ansible-lint module.


### PR DESCRIPTION
Add images badges from MicroBadger and Anchore.io to the README file. They show the image's size and provide access to more information.