### PR TITLE
Update Ansible Lint to 4.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.2-alpine3.9
 
-ENV ANSIBLE_LINT_VERSION=3.4.23
+ENV ANSIBLE_LINT_VERSION=4.1.0
 
 RUN apk add --no-cache --virtual .build-deps \
       make \
@@ -25,6 +25,6 @@ CMD ["/usr/local/bin/ansible-lint", "--help"]
 
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.name="ansible-lint" \
-      org.label-schema.version="3.4.21" \
+      org.label-schema.version="4.1.0" \
       org.label-schema.url="https://github.com/willthames/ansible-lint" \
       org.label-schema.vcs-url="https://github.com/oildex/docker-ansible-lint"


### PR DESCRIPTION
Update Ansible Lint to the latest version (4.1.0, released February 11,
2019).